### PR TITLE
Ignore some updates based on attribute on model

### DIFF
--- a/src/UpdatedBy.php
+++ b/src/UpdatedBy.php
@@ -7,6 +7,24 @@ trait UpdatedBy
     {
         static::saving(function ($model)
         {
+            // we want to check to see if anything has actually changed on the model first
+            if (isset($model->ignore_updates) && $model->updated_by && $model->updated_by != 1) {
+                $changes = $model->getDirty();
+                $updated = [];
+                foreach ($changes as $key => $value) {
+                    if (!in_array($key, $model->ignore_updates)) {
+                        if ($original = $model->getOriginal($key)) {
+                            if ($original != $value) {
+                                $updated[$key] = $value;
+                            }
+                        }
+                    }
+                }
+                if (count($updated) == 0) {
+                    return;
+                }
+            }
+
             if(!\Auth::guest())
             {
                 $model->updated_by = \Auth::user()->id;


### PR DESCRIPTION
If you set an array attribute on the model called `ignore_updates`, the trait will not overwrite the updated_by if the only fields changed on the model are in this array.  If there is no `updated_by`, or this array doesn't exist, it will set the updated by as normal.

```php
use Illuminate\Database\Eloquent\Model;
use Koodoo\laravelTraitUpdatedBy\UpdatedBy;

class Foo extends Model {
    use UpdatedBy;

    public $ignore_updates = [
        'company_id',
        'updated_by',
        'updated_at',
        'created_at',
        'other_field'
   ];
}
```
